### PR TITLE
chore: fix bin package field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "belly-button -f"
   },
   "bin": {
-    "lts": "./bin/lts.js"
+    "lts": "bin/lts.js"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
Fixes the following warning emitted by npm:

npm auto-corrected some errors in your package.json when publishing.
Please run "npm pkg fix" to address these errors.
